### PR TITLE
Fix delete shopping cart route

### DIFF
--- a/Sources/App/Controllers/ShoppingCartController.swift
+++ b/Sources/App/Controllers/ShoppingCartController.swift
@@ -33,8 +33,14 @@ struct ShoppingCartController {
         return shoppingCart.update(on: req.db).map { shoppingCart }
     }
 
-    func delete(req: Request) throws -> EventLoopFuture<ShoppingCart> {
-        let shoppingCart = try req.content.decode(ShoppingCart.self)
-        return shoppingCart.delete(on: req.db).map { shoppingCart }
+    func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
+        guard let id = req.parameters.get("id", as: UUID.self) else {
+            throw Abort(.badRequest)
+        }
+
+        return ShoppingCart.find(id, on: req.db)
+            .unwrap(or: Abort(.notFound))
+            .flatMap { $0.delete(on: req.db) }
+            .map { .ok }
     }
 }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -25,7 +25,7 @@ func routes(_ app: Application) throws {
     /// Replace the shopping cart in database
     shoppingCart.put("update", use: shoppingCartController.update)
     /// Delete the shopping cart in database
-    shoppingCart.delete("delete", use: shoppingCartController.delete)
+    shoppingCart.delete("delete", ":id", use: shoppingCartController.delete)
 }
 
 


### PR DESCRIPTION
### What is in this PR

This PR fixes the route and controller for deleting a shopping cart. 

The next steps will be to add this call once a shopping cart is successfully submitted. 

In Postman - delete-shopping-cart request should look as follows:
`http://127.0.0.1:8080/shoppingCart/delete/{shoppingCartId}`